### PR TITLE
Add Civitai sampler name

### DIFF
--- a/py/capture.py
+++ b/py/capture.py
@@ -97,7 +97,7 @@ class Capture:
                 if scheduler != "normal":
                     pnginfo_dict["Sampler"] += "_" + scheduler
 
-        update_pnginfo_dict(inputs_before_sampler_node, MetaField.CFG, "CFG Scale")
+        update_pnginfo_dict(inputs_before_sampler_node, MetaField.CFG, "CFG scale")
         update_pnginfo_dict(inputs_before_sampler_node, MetaField.SEED, "Seed")
 
         update_pnginfo_dict(

--- a/py/nodes/node.py
+++ b/py/nodes/node.py
@@ -51,6 +51,7 @@ class SaveImageWithMetaData(BaseNode):
                 "quality": ("INT", {"default": 100, "min": 1, "max": 100}),
                 "save_workflow_json": ("BOOLEAN", {"default": False}),
                 "add_counter_to_filename": ("BOOLEAN", {"default": True}),
+                "civitai_sampler": ("BOOLEAN", {"default": False})
             },
             "hidden": {"prompt": "PROMPT", "extra_pnginfo": "EXTRA_PNGINFO"},
         }
@@ -73,11 +74,12 @@ class SaveImageWithMetaData(BaseNode):
         quality=100,
         save_workflow_json=False,
         add_counter_to_filename=True,
+        civitai_sampler = False,
         prompt=None,
         extra_pnginfo=None,
     ):
         pnginfo_dict_src = self.gen_pnginfo(
-            sampler_selection_method, sampler_selection_node_id
+            sampler_selection_method, sampler_selection_node_id, civitai_sampler
         )
         results = list()
         for index, image in enumerate(images):
@@ -160,7 +162,7 @@ class SaveImageWithMetaData(BaseNode):
         return {"ui": {"images": results}}
 
     @classmethod
-    def gen_pnginfo(cls, sampler_selection_method, sampler_selection_node_id):
+    def gen_pnginfo(cls, sampler_selection_method, sampler_selection_node_id, save_civitai_sampler):
         # get all node inputs
         inputs = Capture.get_inputs()
 
@@ -185,7 +187,7 @@ class SaveImageWithMetaData(BaseNode):
 
         # generate PNGInfo from inputs
         pnginfo_dict = Capture.gen_pnginfo_dict(
-            inputs_before_sampler_node, inputs_before_this_node
+            inputs_before_sampler_node, inputs_before_this_node, save_civitai_sampler
         )
         return pnginfo_dict
 


### PR DESCRIPTION
This pull request converts ComfyUI sampler + scheduler name combo to Civitai pretty sampler name. I implement the functionality as optional, disabled by default to preserve the old behavior. It can be enabled by setting `civitai_sampler` to true.

![Screenshot_20240820_011222](https://github.com/user-attachments/assets/82a4d312-b01b-4993-947b-749181384124)

![Screenshot_20240820_010816](https://github.com/user-attachments/assets/0eca6cd7-de36-4277-a8ed-8e3a5bbef396)

This PR also fixes a typo of CFG scale metadata:
- `CFG Scale` to `CFG scale`.