### PR TITLE
Fixing the issue of connections forming loops between nodes

### DIFF
--- a/py/trace.py
+++ b/py/trace.py
@@ -10,6 +10,8 @@ class Trace:
         class_type = prompt[start_node_id]["class_type"]
         Q = deque()
         Q.append((start_node_id, 0))
+        visited = set()  # Keep track of visited nodes
+        visited.add(start_node_id)
         trace_tree = {start_node_id: (0, class_type)}
         while len(Q) > 0:
             current_node_id, distance = Q.popleft()
@@ -17,9 +19,11 @@ class Trace:
             for value in input_fields.values():
                 if isinstance(value, list):
                     nid = value[0]
-                    class_type = prompt[nid]["class_type"]
-                    trace_tree[nid] = (distance + 1, class_type)
-                    Q.append((nid, distance + 1))
+                    if nid not in visited:  # Ensure the node is not visited
+                        class_type = prompt[nid]["class_type"]
+                        trace_tree[nid] = (distance + 1, class_type)
+                        Q.append((nid, distance + 1))
+                        visited.add(nid)  # Mark the node as visited
         return trace_tree
 
     @classmethod


### PR DESCRIPTION
Recently, I've been attempting to use SaveImageWithMetaData in some very complex workflows. Honestly, it's excellent for populating metadata. 

However, during my recent run, I noticed the waiting time was extremely long. After examining it with a debugger, I found it frequently pausing in the `trace.py trace()` function. 
![image](https://github.com/user-attachments/assets/bcb05bb5-8d33-4b72-8444-6da7141819d9)
Specifically, I discovered that the total size of Q reached over 100,000, while my workflow had fewer than 2,000 nodes total. Therefore, I initially assessed that the traverse operation wasn't performing deduplication, causing some nodes to be calculated multiple times. In this MR, I attempted to implement deduplication to prevent nodes from being recalculated. 

After the modification, the overall runtime decreased from 280 seconds to infinity, to under 1 minute. And the output metadata appears to be correct.