### PR TITLE
Fix parsing of embedding names with trailing punctuation

### DIFF
--- a/py/defs/formatters.py
+++ b/py/defs/formatters.py
@@ -1,4 +1,5 @@
 import os
+import string
 
 import folder_paths
 
@@ -99,7 +100,7 @@ def _extract_embedding_names(text, input_data):
                 word.startswith(embedding_identifier)
                 and clip.embedding_directory is not None
             ):
-                embedding_name = word[len(embedding_identifier) :].strip("\n")
+                embedding_name = word[len(embedding_identifier) :].strip("\n").strip(string.punctuation)
                 embedding_names.append(embedding_name)
 
     return embedding_names, clip


### PR DESCRIPTION
This PR fixes a bug where embedding names with trailing commas (e.g. `embedding:lazyneg, watermark`) would include the comma in the parsed name, causing errors like:

`expected str, bytes or os.PathLike object, not NoneType`

Resolves #78